### PR TITLE
simplify core and improve coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "lint": "eslint src",
     "build": "rm -rf build && tsc -b",
     "format": "prettier --ignore-path .eslintignore --write .",
-    "c8": "npx --yes c8 --exclude demo uvu -r tsm -r esm tests",
-    "test": "uvu -r tsm -r esm tests",
+    "c8": "npx --yes c8 --exclude demo uvu -r tsm tests",
+    "test": "uvu -r tsm tests",
     "demo": "vite serve demo --host"
   },
   "main": "build/index.js",

--- a/tests/index.js
+++ b/tests/index.js
@@ -106,19 +106,29 @@ const testUseVars = (key, options) => {
   return TestUseVars;
 };
 
+const nIntFormat = {
+  keys: ["n"],
+  decode: parseInt,
+  encode: (x) => `${x}`,
+};
+const sNoFormat = {
+  keys: ["s"],
+};
+
 [
   testExample("default", { value: -1 }),
   testUseVars("integer n", {
     io: testRoutes([["/:n"]], {
-      formats: [
-        {
-          keys: ["n"],
-          decode: parseInt,
-          encode: (x) => `${x}`,
-        },
-      ],
+      formats: [nIntFormat],
     }),
     expected: { n: 42 },
     input: "/42",
+  }),
+  testUseVars("integer n, string s", {
+    io: testRoutes([["/:n", ":s"]], {
+      formats: [nIntFormat, sNoFormat],
+    }),
+    expected: { n: 42, s: "hello" },
+    input: "/42/hello",
   }),
 ].map((test) => test.run());


### PR DESCRIPTION
- Remove needless `esm` loader
- Add additional test case
- Simplify core loop